### PR TITLE
Update conda-content-trust to 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-content-trust" %}
-{% set version = "0.2.0" %}
-{% set sha256 = "ded769f69a0491bd1e002ce949a332ae5a47a60ce733adb8a724802c8fdfe02b" %}
+{% set version = "0.3.0" %}
+{% set sha256 = "518907b0906cda2defd2f2b30b8aeea51e3ca8748ae879c9a1b1de4a4031af95" %}
 
 package:
   name: {{ name }}
@@ -12,20 +12,21 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  skip: true  # [py<38]
+  number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - conda-content-trust = conda_content_trust.cli:cli
 
 requirements:
   host:
-    - python
+    - python >=3.10
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
   run:
-    - python
+    - python >=3.10
+    - conda >=26.3.0
     - cryptography >=41
 
 test:


### PR DESCRIPTION
## Description

Update conda-content-trust from 0.2.0 to 0.3.0.

### Changes in 0.3.0

**Enhancements:**
- Add `CondaPostSolve` plugin hook for signature verification, migrated from `conda.trust.signature_verification`. This enables automatic package signature verification when conda's `extra_safety_checks` is enabled and a trust root is installed (e.g., via `conda-anaconda-trust-root`).
- Add `verification` module with `_SignatureVerification` class for verifying package metadata signatures during conda's solve phase.
- Add `constants` module with `KEY_MGR_FILE` constant, migrated from `conda.trust.constants`.
- Add support for Python 3.13 and 3.14.

**Deprecations:**
- Drop support for Python 3.8 and 3.9.

Full changelog: https://github.com/conda/conda-content-trust/blob/0.3.x/CHANGELOG.md

### Recipe changes

- Bump version to 0.3.0, reset build number to 0.
- Update sha256 hash for the new source tarball.
- Update `skip` directive from `py<38` to `py<310` (Python 3.8/3.9 dropped).
- Add `python >=3.10` pin to host and run requirements.
- Add `conda >=26.3.0` run dependency (the signature verification plugin requires conda's `CondaPostSolve` hook).

## Checklist
- [x] Source URL and sha256 updated
- [x] Build number reset to 0
- [x] Python version constraints updated
- [x] New runtime dependency (`conda >=26.3.0`) added
- [x] Test imports and commands verified