### PR TITLE
Update conda-content-trust to 0.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
   run:
-    - python >=3.10
+    - python
     - conda >=26.3.0
     - cryptography >=41
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-content-trust" %}
-{% set version = "0.3.0" %}
-{% set sha256 = "518907b0906cda2defd2f2b30b8aeea51e3ca8748ae879c9a1b1de4a4031af95" %}
+{% set version = "0.3.1" %}
+{% set sha256 = "29edab3cf40e63231ec52109ce1ae1036ba09450ff3923f24eb4d1c79c8a636c" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-content-trust" %}
-{% set version = "0.2.0" %}
-{% set sha256 = "ded769f69a0491bd1e002ce949a332ae5a47a60ce733adb8a724802c8fdfe02b" %}
+{% set version = "0.3.0" %}
+{% set sha256 = "518907b0906cda2defd2f2b30b8aeea51e3ca8748ae879c9a1b1de4a4031af95" %}
 
 package:
   name: {{ name }}
@@ -12,20 +12,21 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  skip: true  # [py<38]
+  number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - conda-content-trust = conda_content_trust.cli:cli
 
 requirements:
   host:
-    - python
+    - python >=3.10
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
   run:
-    - python
+    - python >=3.10
+    - conda >=26.3.0
     - cryptography >=41
 
 test:


### PR DESCRIPTION
conda-content-trust 0.3.1

**Destination channel:** defaults

### Links

* [conda-content-trust 0.3.1 release](https://github.com/conda/conda-content-trust/releases/tag/0.3.1)
* [Upstream repository](https://github.com/conda/conda-content-trust)
* [PKG-13352](https://anaconda.atlassian.net/browse/PKG-13352)
* Relevant dependency PRs:
  * conda/conda#15649 - Remove conda.trust signature verification (feature migrated to conda-content-trust)

### Explanation of changes:

* Bump version from 0.2.0 to 0.3.1, reset build number to 0.
* Update sha256 hash for the new source tarball.
* Update `skip` directive from `py<38` to `py<310` (Python 3.8/3.9 dropped upstream).
* Add `python >=3.10` pin to host and run requirements.
* Add `conda >=26.3.0` run dependency (the new `CondaPostSolve` signature verification plugin requires conda's plugin hook).

### 0.3.1 bugfix (vs 0.3.0):

* Fix `conda.plugins` import ([#260](https://github.com/conda/conda-content-trust/pull/260)).

[PKG-13352]: https://anaconda.atlassian.net/browse/PKG-13352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ