### PR TITLE
Update conda-content-trust to 0.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-content-trust" %}
-{% set version = "0.3.1" %}
-{% set sha256 = "29edab3cf40e63231ec52109ce1ae1036ba09450ff3923f24eb4d1c79c8a636c" %}
+{% set version = "0.3.2" %}
+{% set sha256 = "6d459ca40d3775220ad7a2886a7c367a0d966b47cc0b97f27fb6be0439e361c9" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
conda-content-trust 0.3.2

**Destination channel:** defaults

### Links

* [conda-content-trust 0.3.2 release](https://github.com/conda/conda-content-trust/releases/tag/0.3.2)
* [Upstream repository](https://github.com/conda/conda-content-trust)

### Explanation of changes

* Bump version from `0.3.1` to `0.3.2`, build number stays at `0`.
* Update `sha256` hash for the new source tarball.

### 0.3.2 bugfix (vs 0.3.1)

* Fix `AttributeError: module 'cryptography.hazmat' has no attribute 'backends'` in `verify_gpg_signature` (and therefore `verify_root` and `verify_signable(..., gpg=True)`) on `cryptography >= 44`. The function now imports `cryptography.hazmat.primitives.hashes` explicitly and drops the unused `backend=` argument to `Hash()`. ([#264](https://github.com/conda/conda-content-trust/issues/264) via [#265](https://github.com/conda/conda-content-trust/pull/265))
